### PR TITLE
Support P2TR as sweep/change address everywhere

### DIFF
--- a/btc/explorer_api.go
+++ b/btc/explorer_api.go
@@ -196,13 +196,17 @@ func (a *ExplorerAPI) PublishTx(rawTxHex string) (string, error) {
 	url := fmt.Sprintf("%s/tx", a.BaseURL)
 	resp, err := http.Post(url, "text/plain", strings.NewReader(rawTxHex))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error posting data to API '%s', "+
+			"server might be experiencing temporary issues, try "+
+			"again later; error details: %w", url, err)
 	}
 	defer resp.Body.Close()
 	body := new(bytes.Buffer)
 	_, err = body.ReadFrom(resp.Body)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error fetching data from API '%s', "+
+			"server might be experiencing temporary issues, try "+
+			"again later; error details: %w", url, err)
 	}
 	return body.String(), nil
 }
@@ -210,20 +214,29 @@ func (a *ExplorerAPI) PublishTx(rawTxHex string) (string, error) {
 func fetchJSON(url string, target interface{}) error {
 	resp, err := http.Get(url)
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching data from API '%s', "+
+			"server might be experiencing temporary issues, try "+
+			"again later; error details: %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	body := new(bytes.Buffer)
 	_, err = body.ReadFrom(resp.Body)
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching data from API '%s', "+
+			"server might be experiencing temporary issues, try "+
+			"again later; error details: %w", url, err)
 	}
 	err = json.Unmarshal(body.Bytes(), target)
 	if err != nil {
 		if body.String() == "Transaction not found" {
 			return ErrTxNotFound
 		}
+
+		return fmt.Errorf("error decoding data from API '%s', "+
+			"server might be experiencing temporary issues, try "+
+			"again later; error details: %w", url, err)
 	}
-	return err
+
+	return nil
 }

--- a/btc/summary.go
+++ b/btc/summary.go
@@ -7,13 +7,12 @@ import (
 	"github.com/lightninglabs/chantools/dataformat"
 )
 
-func SummarizeChannels(apiURL string, channels []*dataformat.SummaryEntry,
+func SummarizeChannels(api *ExplorerAPI, channels []*dataformat.SummaryEntry,
 	log btclog.Logger) (*dataformat.SummaryEntryFile, error) {
 
 	summaryFile := &dataformat.SummaryEntryFile{
 		Channels: channels,
 	}
-	api := &ExplorerAPI{BaseURL: apiURL}
 
 	for idx, channel := range channels {
 		tx, err := api.Transaction(channel.FundingTXID)

--- a/cmd/chantools/closepoolaccount.go
+++ b/cmd/chantools/closepoolaccount.go
@@ -88,7 +88,9 @@ obtained by running 'pool accounts list' `,
 			"API instead of just printing the TX",
 	)
 	cc.cmd.Flags().StringVar(
-		&cc.SweepAddr, "sweepaddr", "", "address to sweep the funds to",
+		&cc.SweepAddr, "sweepaddr", "", "address to recover the funds "+
+			"to; specify '"+lnd.AddressDeriveFromWallet+"' to "+
+			"derive a new address from the seed automatically",
 	)
 	cc.cmd.Flags().Uint32Var(
 		&cc.FeeRate, "feerate", defaultFeeSatPerVByte, "fee rate to "+
@@ -124,8 +126,12 @@ func (c *closePoolAccountCommand) Execute(_ *cobra.Command, _ []string) error {
 	}
 
 	// Make sure sweep addr is set.
-	if c.SweepAddr == "" {
-		return fmt.Errorf("sweep addr is required")
+	err = lnd.CheckAddress(
+		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
+		lnd.AddrTypeP2TR,
+	)
+	if err != nil {
+		return err
 	}
 
 	// Parse account outpoint and auctioneer key.

--- a/cmd/chantools/closepoolaccount.go
+++ b/cmd/chantools/closepoolaccount.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightninglabs/pool/account"
 	"github.com/lightninglabs/pool/poolscript"
@@ -165,7 +164,7 @@ func closePoolAccount(extendedKey *hdkeychain.ExtendedKey, apiURL string,
 		ExtendedKey: extendedKey,
 		ChainParams: chainParams,
 	}
-	api := &btc.ExplorerAPI{BaseURL: apiURL}
+	api := newExplorerAPI(apiURL)
 
 	tx, err := api.Transaction(outpoint.Hash.String())
 	if err != nil {

--- a/cmd/chantools/doublespendinputs.go
+++ b/cmd/chantools/doublespendinputs.go
@@ -34,16 +34,16 @@ type doubleSpendInputs struct {
 func newDoubleSpendInputsCommand() *cobra.Command {
 	cc := &doubleSpendInputs{}
 	cc.cmd = &cobra.Command{
-		Use: "doublespendinputs",
-		Short: "Tries to double spend the given inputs by deriving the " +
-			"private for the address and sweeping the funds to the given " +
-			"address. This can only be used with inputs that belong to " +
-			"an lnd wallet.",
+		Use:   "doublespendinputs",
+		Short: "Replace a transaction by double spending its input",
+		Long: `Tries to double spend the given inputs by deriving the
+private for the address and sweeping the funds to the given address. This can
+only be used with inputs that belong to an lnd wallet.`,
 		Example: `chantools doublespendinputs \
-		--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
-		--sweepaddr bc1q..... \
-		--feerate 10 \
-		--publish`,
+	--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
+	--sweepaddr bc1q..... \
+	--feerate 10 \
+	--publish`,
 		RunE: cc.Execute,
 	}
 	cc.cmd.Flags().StringVar(
@@ -55,7 +55,9 @@ func newDoubleSpendInputsCommand() *cobra.Command {
 		"list of outpoints to double spend in the format txid:vout",
 	)
 	cc.cmd.Flags().StringVar(
-		&cc.SweepAddr, "sweepaddr", "", "address to sweep the funds to",
+		&cc.SweepAddr, "sweepaddr", "", "address to recover the funds "+
+			"to; specify '"+lnd.AddressDeriveFromWallet+"' to "+
+			"derive a new address from the seed automatically",
 	)
 	cc.cmd.Flags().Uint32Var(
 		&cc.FeeRate, "feerate", defaultFeeSatPerVByte, "fee rate to "+
@@ -83,8 +85,12 @@ func (c *doubleSpendInputs) Execute(_ *cobra.Command, _ []string) error {
 	}
 
 	// Make sure sweep addr is set.
-	if c.SweepAddr == "" {
-		return fmt.Errorf("sweep addr is required")
+	err = lnd.CheckAddress(
+		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
+		lnd.AddrTypeP2TR,
+	)
+	if err != nil {
+		return err
 	}
 
 	// Make sure we have at least one input.

--- a/cmd/chantools/doublespendinputs.go
+++ b/cmd/chantools/doublespendinputs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -93,7 +92,7 @@ func (c *doubleSpendInputs) Execute(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("inputoutpoints are required")
 	}
 
-	api := &btc.ExplorerAPI{BaseURL: c.APIURL}
+	api := newExplorerAPI(c.APIURL)
 
 	addresses := make([]btcutil.Address, 0, len(c.InputOutpoints))
 	outpoints := make([]*wire.OutPoint, 0, len(c.InputOutpoints))

--- a/cmd/chantools/forceclose.go
+++ b/cmd/chantools/forceclose.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/txscript"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/dataformat"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -105,7 +104,7 @@ func forceCloseChannels(apiURL string, extendedKey *hdkeychain.ExtendedKey,
 	if err != nil {
 		return err
 	}
-	api := &btc.ExplorerAPI{BaseURL: apiURL}
+	api := newExplorerAPI(apiURL)
 	signer := &lnd.Signer{
 		ExtendedKey: extendedKey,
 		ChainParams: chainParams,

--- a/cmd/chantools/pullanchor.go
+++ b/cmd/chantools/pullanchor.go
@@ -132,7 +132,7 @@ func createPullTransactionTemplate(rootKey *hdkeychain.ExtendedKey,
 		ExtendedKey: rootKey,
 		ChainParams: chainParams,
 	}
-	api := &btc.ExplorerAPI{BaseURL: apiURL}
+	api := newExplorerAPI(apiURL)
 	estimator := input.TxWeightEstimator{}
 
 	// Make sure the sponsor input is a P2WPKH or P2TR input and is known

--- a/cmd/chantools/recoverloopin.go
+++ b/cmd/chantools/recoverloopin.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/loopdb"
@@ -121,7 +120,7 @@ func (c *recoverLoopInCommand) Execute(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("sweep_addr is required")
 	}
 
-	api := &btc.ExplorerAPI{BaseURL: c.APIURL}
+	api := newExplorerAPI(c.APIURL)
 
 	signer := &lnd.Signer{
 		ExtendedKey: extendedKey,

--- a/cmd/chantools/recoverloopin.go
+++ b/cmd/chantools/recoverloopin.go
@@ -69,8 +69,9 @@ func newRecoverLoopInCommand() *cobra.Command {
 			"database directory, where the loop.db file is located",
 	)
 	cc.cmd.Flags().StringVar(
-		&cc.SweepAddr, "sweep_addr", "", "address to recover "+
-			"the funds to",
+		&cc.SweepAddr, "sweepaddr", "", "address to recover the funds "+
+			"to; specify '"+lnd.AddressDeriveFromWallet+"' to "+
+			"derive a new address from the seed automatically",
 	)
 	cc.cmd.Flags().Uint32Var(
 		&cc.FeeRate, "feerate", 0, "fee rate to "+
@@ -116,12 +117,15 @@ func (c *recoverLoopInCommand) Execute(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("loop_db_dir is required")
 	}
 
-	if c.SweepAddr == "" {
-		return fmt.Errorf("sweep_addr is required")
+	err = lnd.CheckAddress(
+		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
+		lnd.AddrTypeP2TR,
+	)
+	if err != nil {
+		return err
 	}
 
 	api := newExplorerAPI(c.APIURL)
-
 	signer := &lnd.Signer{
 		ExtendedKey: extendedKey,
 		ChainParams: chainParams,

--- a/cmd/chantools/rescuefunding.go
+++ b/cmd/chantools/rescuefunding.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -255,7 +254,7 @@ func rescueFunding(localKeyDesc *keychain.KeyDescriptor,
 	}
 
 	// Locate the output in the funding TX.
-	api := &btc.ExplorerAPI{BaseURL: apiURL}
+	api := newExplorerAPI(apiURL)
 	tx, err := api.Transaction(chainPoint.Hash.String())
 	if err != nil {
 		return fmt.Errorf("error fetching UTXO info for outpoint %s: "+

--- a/cmd/chantools/rescuefunding.go
+++ b/cmd/chantools/rescuefunding.go
@@ -112,7 +112,9 @@ chantools rescuefunding \
 			"specified manually",
 	)
 	cc.cmd.Flags().StringVar(
-		&cc.SweepAddr, "sweepaddr", "", "address to sweep the funds to",
+		&cc.SweepAddr, "sweepaddr", "", "address to recover the funds "+
+			"to; specify '"+lnd.AddressDeriveFromWallet+"' to "+
+			"derive a new address from the seed automatically",
 	)
 	cc.cmd.Flags().Uint32Var(
 		&cc.FeeRate, "feerate", defaultFeeSatPerVByte, "fee rate to "+
@@ -224,6 +226,14 @@ func (c *rescueFundingCommand) Execute(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("error parsing confirmed channel "+
 				"point: %w", err)
 		}
+	}
+
+	err = lnd.CheckAddress(
+		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
+		lnd.AddrTypeP2TR,
+	)
+	if err != nil {
+		return err
 	}
 
 	// Make sure the sweep addr is a P2WKH address so we can do accurate

--- a/cmd/chantools/root.go
+++ b/cmd/chantools/root.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	defaultAPIURL = "https://blockstream.info/api"
+	defaultAPIURL        = "https://blockstream.info/api"
+	defaultTestnetAPIURL = "https://blockstream.info/testnet/api"
+	defaultRegtestAPIURL = "http://localhost:3004"
 
 	// version is the current version of the tool. It is set during build.
 	// NOTE: When changing this, please also update the version in the
@@ -56,7 +58,8 @@ var rootCmd = &cobra.Command{
 	Short: "Chantools helps recover funds from lightning channels",
 	Long: `This tool provides helper functions that can be used rescue
 funds locked in lnd channels in case lnd itself cannot run properly anymore.
-Complete documentation is available at https://github.com/lightninglabs/chantools/.`,
+Complete documentation is available at
+https://github.com/lightninglabs/chantools/.`,
 	Version: fmt.Sprintf("v%s, commit %s", version, Commit),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		switch {
@@ -325,4 +328,23 @@ func setSubLogger(subsystem string, logger btclog.Logger,
 
 func noConsole() ([]byte, error) {
 	return nil, fmt.Errorf("wallet db requires console access")
+}
+
+func newExplorerAPI(apiURL string) *btc.ExplorerAPI {
+	// Override for testnet if default is used.
+	if apiURL == defaultAPIURL &&
+		chainParams.Name == chaincfg.TestNet3Params.Name {
+
+		return &btc.ExplorerAPI{BaseURL: defaultTestnetAPIURL}
+	}
+
+	// Also override for regtest if default is used.
+	if apiURL == defaultAPIURL &&
+		chainParams.Name == chaincfg.RegressionNetParams.Name {
+
+		return &btc.ExplorerAPI{BaseURL: defaultRegtestAPIURL}
+	}
+
+	// Otherwise use the provided URL.
+	return &btc.ExplorerAPI{BaseURL: apiURL}
 }

--- a/cmd/chantools/summary.go
+++ b/cmd/chantools/summary.go
@@ -53,7 +53,8 @@ func (c *summaryCommand) Execute(_ *cobra.Command, _ []string) error {
 func summarizeChannels(apiURL string,
 	channels []*dataformat.SummaryEntry) error {
 
-	summaryFile, err := btc.SummarizeChannels(apiURL, channels, log)
+	api := newExplorerAPI(apiURL)
+	summaryFile, err := btc.SummarizeChannels(api, channels, log)
 	if err != nil {
 		return fmt.Errorf("error running summary: %w", err)
 	}

--- a/cmd/chantools/sweepremoteclosed.go
+++ b/cmd/chantools/sweepremoteclosed.go
@@ -129,7 +129,7 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 
 	var (
 		targets []*targetAddr
-		api     = &btc.ExplorerAPI{BaseURL: apiURL}
+		api     = newExplorerAPI(apiURL)
 	)
 	for index := uint32(0); index < recoveryWindow; index++ {
 		path := fmt.Sprintf("m/1017'/%d'/%d'/0/%d",

--- a/cmd/chantools/sweeptimelock.go
+++ b/cmd/chantools/sweeptimelock.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/dataformat"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/input"
@@ -220,7 +219,7 @@ func sweepTimeLock(extendedKey *hdkeychain.ExtendedKey, apiURL string,
 		ExtendedKey: extendedKey,
 		ChainParams: chainParams,
 	}
-	api := &btc.ExplorerAPI{BaseURL: apiURL}
+	api := newExplorerAPI(apiURL)
 
 	var (
 		sweepTx          = wire.NewMsgTx(2)

--- a/cmd/chantools/sweeptimelock.go
+++ b/cmd/chantools/sweeptimelock.go
@@ -64,7 +64,9 @@ parameter to 144.`,
 			"API instead of just printing the TX",
 	)
 	cc.cmd.Flags().StringVar(
-		&cc.SweepAddr, "sweepaddr", "", "address to sweep the funds to",
+		&cc.SweepAddr, "sweepaddr", "", "address to recover the funds "+
+			"to; specify '"+lnd.AddressDeriveFromWallet+"' to "+
+			"derive a new address from the seed automatically",
 	)
 	cc.cmd.Flags().Uint16Var(
 		&cc.MaxCsvLimit, "maxcsvlimit", defaultCsvLimit, "maximum CSV "+
@@ -88,8 +90,12 @@ func (c *sweepTimeLockCommand) Execute(_ *cobra.Command, _ []string) error {
 	}
 
 	// Make sure sweep addr is set.
-	if c.SweepAddr == "" {
-		return fmt.Errorf("sweep addr is required")
+	err = lnd.CheckAddress(
+		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
+		lnd.AddrTypeP2TR,
+	)
+	if err != nil {
+		return err
 	}
 
 	// Parse channel entries from any of the possible input files.

--- a/cmd/chantools/sweeptimelockmanual.go
+++ b/cmd/chantools/sweeptimelockmanual.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -298,7 +297,7 @@ func sweepTimeLockManual(extendedKey *hdkeychain.ExtendedKey, apiURL string,
 		ExtendedKey: extendedKey,
 		ChainParams: chainParams,
 	}
-	api := &btc.ExplorerAPI{BaseURL: apiURL}
+	api := newExplorerAPI(apiURL)
 
 	// We now know everything we need to construct the sweep transaction,
 	// except for what outpoint to sweep. We'll ask the chain API to give

--- a/cmd/chantools/sweeptimelockmanual.go
+++ b/cmd/chantools/sweeptimelockmanual.go
@@ -89,7 +89,9 @@ chantools sweeptimelockmanual \
 			"API instead of just printing the TX",
 	)
 	cc.cmd.Flags().StringVar(
-		&cc.SweepAddr, "sweepaddr", "", "address to sweep the funds to",
+		&cc.SweepAddr, "sweepaddr", "", "address to recover the funds "+
+			"to; specify '"+lnd.AddressDeriveFromWallet+"' to "+
+			"derive a new address from the seed automatically",
 	)
 	cc.cmd.Flags().Uint16Var(
 		&cc.MaxCsvLimit, "maxcsvlimit", defaultCsvLimit, "maximum CSV "+
@@ -142,11 +144,20 @@ func (c *sweepTimeLockManualCommand) Execute(_ *cobra.Command, _ []string) error
 	}
 
 	// Make sure the sweep and time lock addrs are set.
-	if c.SweepAddr == "" {
-		return fmt.Errorf("sweep addr is required")
+	err = lnd.CheckAddress(
+		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
+		lnd.AddrTypeP2TR,
+	)
+	if err != nil {
+		return err
 	}
-	if c.TimeLockAddr == "" {
-		return fmt.Errorf("time lock addr is required")
+
+	err = lnd.CheckAddress(
+		c.TimeLockAddr, chainParams, true, "time lock",
+		lnd.AddrTypeP2WSH,
+	)
+	if err != nil {
+		return err
 	}
 
 	var (

--- a/cmd/chantools/triggerforceclose.go
+++ b/cmd/chantools/triggerforceclose.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/brontide"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -152,7 +151,7 @@ func (c *triggerForceCloseCommand) Execute(_ *cobra.Command, _ []string) error {
 	log.Infof("Message sent, waiting for force close transaction to " +
 		"appear in mempool")
 
-	api := &btc.ExplorerAPI{BaseURL: c.APIURL}
+	api := newExplorerAPI(c.APIURL)
 	channelAddress, err := api.Address(c.ChannelPoint)
 	if err != nil {
 		return fmt.Errorf("error getting channel address: %w", err)

--- a/cmd/chantools/zombierecovery_findmatches.go
+++ b/cmd/chantools/zombierecovery_findmatches.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/hasura/go-graphql-client"
-	"github.com/lightninglabs/chantools/btc"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
@@ -188,7 +187,7 @@ func (c *zombieRecoveryFindMatchesCommand) Execute(_ *cobra.Command,
 		log.Infof("%s: %s", groups[1], groups[2])
 	}
 
-	api := &btc.ExplorerAPI{BaseURL: c.APIURL}
+	api := newExplorerAPI(c.APIURL)
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.AmbossKey})
 	httpClient := oauth2.NewClient(context.Background(), src)
 	client := graphql.NewClient(

--- a/doc/chantools.md
+++ b/doc/chantools.md
@@ -6,7 +6,8 @@ Chantools helps recover funds from lightning channels
 
 This tool provides helper functions that can be used rescue
 funds locked in lnd channels in case lnd itself cannot run properly anymore.
-Complete documentation is available at https://github.com/lightninglabs/chantools/.
+Complete documentation is available at
+https://github.com/lightninglabs/chantools/.
 
 ### Options
 
@@ -24,7 +25,7 @@ Complete documentation is available at https://github.com/lightninglabs/chantool
 * [chantools compactdb](chantools_compactdb.md)	 - Create a copy of a channel.db file in safe/read-only mode
 * [chantools deletepayments](chantools_deletepayments.md)	 - Remove all (failed) payments from a channel DB
 * [chantools derivekey](chantools_derivekey.md)	 - Derive a key with a specific derivation path
-* [chantools doublespendinputs](chantools_doublespendinputs.md)	 - Tries to double spend the given inputs by deriving the private for the address and sweeping the funds to the given address. This can only be used with inputs that belong to an lnd wallet.
+* [chantools doublespendinputs](chantools_doublespendinputs.md)	 - Replace a transaction by double spending its input
 * [chantools dropchannelgraph](chantools_dropchannelgraph.md)	 - Remove all graph related data from a channel DB
 * [chantools dropgraphzombies](chantools_dropgraphzombies.md)	 - Remove all channels identified as zombies from the graph to force a re-sync of the graph
 * [chantools dumpbackup](chantools_dumpbackup.md)	 - Dump the content of a channel.backup file

--- a/doc/chantools_closepoolaccount.md
+++ b/doc/chantools_closepoolaccount.md
@@ -41,7 +41,7 @@ chantools closepoolaccount \
       --outpoint string          last account outpoint of the account to close (<txid>:<txindex>)
       --publish                  publish sweep TX to the chain API instead of just printing the TX
       --rootkey string           BIP32 HD root key of the wallet to use for deriving keys; leave empty to prompt for lnd 24 word aezeed
-      --sweepaddr string         address to sweep the funds to
+      --sweepaddr string         address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
 ```
 
 ### Options inherited from parent commands

--- a/doc/chantools_doublespendinputs.md
+++ b/doc/chantools_doublespendinputs.md
@@ -1,6 +1,12 @@
 ## chantools doublespendinputs
 
-Tries to double spend the given inputs by deriving the private for the address and sweeping the funds to the given address. This can only be used with inputs that belong to an lnd wallet.
+Replace a transaction by double spending its input
+
+### Synopsis
+
+Tries to double spend the given inputs by deriving the
+private for the address and sweeping the funds to the given address. This can
+only be used with inputs that belong to an lnd wallet.
 
 ```
 chantools doublespendinputs [flags]
@@ -10,10 +16,10 @@ chantools doublespendinputs [flags]
 
 ```
 chantools doublespendinputs \
-		--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
-		--sweepaddr bc1q..... \
-		--feerate 10 \
-		--publish
+	--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
+	--sweepaddr bc1q..... \
+	--feerate 10 \
+	--publish
 ```
 
 ### Options
@@ -27,7 +33,7 @@ chantools doublespendinputs \
       --publish                  publish replacement TX to the chain API instead of just printing the TX
       --recoverywindow uint32    number of keys to scan per internal/external branch; output will consist of double this amount of keys (default 2500)
       --rootkey string           BIP32 HD root key of the wallet to use for deriving the input keys; leave empty to prompt for lnd 24 word aezeed
-      --sweepaddr string         address to sweep the funds to
+      --sweepaddr string         address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
 ```
 
 ### Options inherited from parent commands

--- a/doc/chantools_pullanchor.md
+++ b/doc/chantools_pullanchor.md
@@ -28,7 +28,7 @@ chantools pullanchor \
       --anchoraddr stringArray   the address of the anchor output (p2wsh or p2tr output with 330 satoshis) that should be pulled; can be specified multiple times per command to pull multiple anchors with a single transaction
       --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
       --bip39                    read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
-      --changeaddr string        the change address to send the remaining funds to
+      --changeaddr string        the change address to send the remaining funds back to; specify 'fromseed' to derive a new address from the seed automatically
       --feerate uint32           fee rate to use for the sweep transaction in sat/vByte (default 30)
   -h, --help                     help for pullanchor
       --rootkey string           BIP32 HD root key of the wallet to use for deriving keys; leave empty to prompt for lnd 24 word aezeed

--- a/doc/chantools_recoverloopin.md
+++ b/doc/chantools_recoverloopin.md
@@ -31,7 +31,7 @@ chantools recoverloopin \
       --rootkey string        BIP32 HD root key of the wallet to use for deriving starting key; leave empty to prompt for lnd 24 word aezeed
       --start_key_index int   start key index to try to find the correct key index
       --swap_hash string      swap hash of the loop in swap
-      --sweep_addr string     address to recover the funds to
+      --sweepaddr string      address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
       --txid string           transaction id of the on-chain transaction that created the HTLC
       --vout uint32           output index of the on-chain transaction that created the HTLC
 ```

--- a/doc/chantools_rescuefunding.md
+++ b/doc/chantools_rescuefunding.md
@@ -49,7 +49,7 @@ chantools rescuefunding \
       --localkeyindex uint32           in case a channel DB is not available (but perhaps a channel backup file), the derivation index of the local multisig public key can be specified manually
       --remotepubkey string            in case a channel DB is not available (but perhaps a channel backup file), the remote multisig public key can be specified manually
       --rootkey string                 BIP32 HD root key of the wallet to use for deriving keys; leave empty to prompt for lnd 24 word aezeed
-      --sweepaddr string               address to sweep the funds to
+      --sweepaddr string               address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
 ```
 
 ### Options inherited from parent commands

--- a/doc/chantools_sweepremoteclosed.md
+++ b/doc/chantools_sweepremoteclosed.md
@@ -40,7 +40,7 @@ chantools sweepremoteclosed \
       --publish                 publish sweep TX to the chain API instead of just printing the TX
       --recoverywindow uint32   number of keys to scan per derivation path (default 200)
       --rootkey string          BIP32 HD root key of the wallet to use for sweeping the wallet; leave empty to prompt for lnd 24 word aezeed
-      --sweepaddr string        address to sweep the funds to
+      --sweepaddr string        address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
 ```
 
 ### Options inherited from parent commands

--- a/doc/chantools_sweeptimelock.md
+++ b/doc/chantools_sweeptimelock.md
@@ -40,7 +40,7 @@ chantools sweeptimelock \
       --pendingchannels string   channel input is in the format of lncli's pendingchannels format; specify '-' to read from stdin
       --publish                  publish sweep TX to the chain API instead of just printing the TX
       --rootkey string           BIP32 HD root key of the wallet to use for deriving keys; leave empty to prompt for lnd 24 word aezeed
-      --sweepaddr string         address to sweep the funds to
+      --sweepaddr string         address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
 ```
 
 ### Options inherited from parent commands

--- a/doc/chantools_sweeptimelockmanual.md
+++ b/doc/chantools_sweeptimelockmanual.md
@@ -61,7 +61,7 @@ chantools sweeptimelockmanual \
       --publish                     publish sweep TX to the chain API instead of just printing the TX
       --remoterevbasepoint string   remote node's revocation base point, can be found in a channel.backup file
       --rootkey string              BIP32 HD root key of the wallet to use for deriving keys; leave empty to prompt for lnd 24 word aezeed
-      --sweepaddr string            address to sweep the funds to
+      --sweepaddr string            address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically
       --timelockaddr string         address of the time locked commitment output where the funds are stuck in
 ```
 


### PR DESCRIPTION
With this PR we add P2TR address support to each command that requires the user to specify a sweep or change address.
The user now also has the option to specify `fromseed` as the value for the address in which case a new P2WKH address is derived from the seed directly.