### PR TITLE
zombierecovery: add --matchonly flag to makeoffer, --numkeys to preparekeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Example (make sure you always use the latest version!):
 
 ```shell
 $ cd /tmp
-$ wget -O chantools.tar.gz https://github.com/lightninglabs/chantools/releases/download/v0.12.0/chantools-linux-amd64-v0.12.0.tar.gz
+$ wget -O chantools.tar.gz https://github.com/lightninglabs/chantools/releases/download/v0.12.2/chantools-linux-amd64-v0.12.2.tar.gz
 $ tar -zxvf chantools.tar.gz
 $ sudo mv chantools-*/chantools /usr/local/bin/
 ```

--- a/cmd/chantools/root.go
+++ b/cmd/chantools/root.go
@@ -33,7 +33,7 @@ const (
 	// version is the current version of the tool. It is set during build.
 	// NOTE: When changing this, please also update the version in the
 	// download link shown in the README.
-	version = "0.12.1"
+	version = "0.12.2"
 	na      = "n/a"
 
 	// lndVersion is the current version of lnd that we support. This is


### PR DESCRIPTION
This PR adds two new flags to the zombierecovery workflow that are needed for nodes with a large number of channels.