### PR TITLE
doublespendinputs: allow RBF per default

### DIFF
--- a/cmd/chantools/doublespendinputs.go
+++ b/cmd/chantools/doublespendinputs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -26,6 +27,7 @@ type doubleSpendInputs struct {
 	SweepAddr      string
 	FeeRate        uint32
 	RecoveryWindow uint32
+	Rbf            bool
 
 	rootKey *rootKey
 	cmd     *cobra.Command
@@ -43,6 +45,7 @@ only be used with inputs that belong to an lnd wallet.`,
 	--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
 	--sweepaddr bc1q..... \
 	--feerate 10 \
+	--rbf=true \
 	--publish`,
 		RunE: cc.Execute,
 	}
@@ -67,6 +70,10 @@ only be used with inputs that belong to an lnd wallet.`,
 		&cc.RecoveryWindow, "recoverywindow", defaultRecoveryWindow,
 		"number of keys to scan per internal/external branch; output "+
 			"will consist of double this amount of keys",
+	)
+	cc.cmd.Flags().BoolVar(
+		&cc.Rbf, "rbf", true, "choose RBF flag for this double spend "+
+			"transaction. (Be sure to use '=' with this argument)",
 	)
 	cc.cmd.Flags().BoolVar(
 		&cc.Publish, "publish", false, "publish replacement TX to "+
@@ -230,9 +237,19 @@ func (c *doubleSpendInputs) Execute(_ *cobra.Command, _ []string) error {
 	// Create the transaction.
 	tx := wire.NewMsgTx(2)
 
+	// enable/disable RBF
+	var sequence uint32 = mempool.MaxRBFSequence
+	if !c.Rbf {
+		sequence = wire.MaxTxInSequenceNum
+	}
+
 	// Add the inputs.
 	for _, outpoint := range outpoints {
-		tx.AddTxIn(wire.NewTxIn(outpoint, nil, nil))
+
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: *outpoint,
+			Sequence:         sequence,
+		})
 	}
 
 	tx.AddTxOut(wire.NewTxOut(int64(totalInput-totalFee), sweepScript))

--- a/doc/chantools_doublespendinputs.md
+++ b/doc/chantools_doublespendinputs.md
@@ -19,7 +19,6 @@ chantools doublespendinputs \
 	--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
 	--sweepaddr bc1q..... \
 	--feerate 10 \
-	--rbf=true \
 	--publish
 ```
 
@@ -32,7 +31,6 @@ chantools doublespendinputs \
   -h, --help                     help for doublespendinputs
       --inputoutpoints strings   list of outpoints to double spend in the format txid:vout
       --publish                  publish replacement TX to the chain API instead of just printing the TX
-      --rbf                      choose RBF flag for this double spend transaction. (Be sure to use '=' with this argument) (default true)
       --recoverywindow uint32    number of keys to scan per internal/external branch; output will consist of double this amount of keys (default 2500)
       --rootkey string           BIP32 HD root key of the wallet to use for deriving the input keys; leave empty to prompt for lnd 24 word aezeed
       --sweepaddr string         address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically

--- a/doc/chantools_doublespendinputs.md
+++ b/doc/chantools_doublespendinputs.md
@@ -19,6 +19,7 @@ chantools doublespendinputs \
 	--inputoutpoints xxxxxxxxx:y,xxxxxxxxx:y \
 	--sweepaddr bc1q..... \
 	--feerate 10 \
+	--rbf=true \
 	--publish
 ```
 
@@ -31,6 +32,7 @@ chantools doublespendinputs \
   -h, --help                     help for doublespendinputs
       --inputoutpoints strings   list of outpoints to double spend in the format txid:vout
       --publish                  publish replacement TX to the chain API instead of just printing the TX
+      --rbf                      choose RBF flag for this double spend transaction. (Be sure to use '=' with this argument) (default true)
       --recoverywindow uint32    number of keys to scan per internal/external branch; output will consist of double this amount of keys (default 2500)
       --rootkey string           BIP32 HD root key of the wallet to use for deriving the input keys; leave empty to prompt for lnd 24 word aezeed
       --sweepaddr string         address to recover the funds to; specify 'fromseed' to derive a new address from the seed automatically

--- a/doc/chantools_fakechanbackup.md
+++ b/doc/chantools_fakechanbackup.md
@@ -61,7 +61,7 @@ chantools fakechanbackup --from_channel_graph lncli_describegraph.json \
       --channelpoint string         funding transaction outpoint of the channel to rescue (<txid>:<txindex>) as it is displayed on 1ml.com
       --from_channel_graph string   the full LN channel graph in the JSON format that the 'lncli describegraph' returns
   -h, --help                        help for fakechanbackup
-      --multi_file string           the fake channel backup file to create (default "results/fake-2023-04-11-16-33-35.backup")
+      --multi_file string           the fake channel backup file to create (default "results/fake-2024-01-26-02-27-52.backup")
       --remote_node_addr string     the remote node connection information in the format pubkey@host:port
       --rootkey string              BIP32 HD root key of the wallet to use for encrypting the backup; leave empty to prompt for lnd 24 word aezeed
       --short_channel_id string     the short channel ID in the format <blockheight>x<transactionindex>x<outputindex>

--- a/doc/chantools_recoverloopin.md
+++ b/doc/chantools_recoverloopin.md
@@ -27,6 +27,7 @@ chantools recoverloopin \
   -h, --help                  help for recoverloopin
       --loop_db_dir string    path to the loop database directory, where the loop.db file is located
       --num_tries int         number of tries to try to find the correct key index (default 1000)
+      --output_amt uint       amount of the output to sweep
       --publish               publish sweep TX to the chain API instead of just printing the TX
       --rootkey string        BIP32 HD root key of the wallet to use for deriving starting key; leave empty to prompt for lnd 24 word aezeed
       --start_key_index int   start key index to try to find the correct key index

--- a/doc/chantools_zombierecovery_makeoffer.md
+++ b/doc/chantools_zombierecovery_makeoffer.md
@@ -31,6 +31,7 @@ chantools zombierecovery makeoffer \
       --bip39               read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32      fee rate to use for the sweep transaction in sat/vByte (default 30)
   -h, --help                help for makeoffer
+      --matchonly           only match the keys, don't create an offer
       --node1_keys string   the JSON file generated in theprevious step ('preparekeys') command of node 1
       --node2_keys string   the JSON file generated in theprevious step ('preparekeys') command of node 2
       --rootkey string      BIP32 HD root key of the wallet to use for signing the offer; leave empty to prompt for lnd 24 word aezeed

--- a/doc/chantools_zombierecovery_preparekeys.md
+++ b/doc/chantools_zombierecovery_preparekeys.md
@@ -28,6 +28,7 @@ chantools zombierecovery preparekeys \
       --bip39                read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
   -h, --help                 help for preparekeys
       --match_file string    the match JSON file that was sent to both nodes by the match maker
+      --num_keys uint32      the number of multisig keys to derive (default 2500)
       --payout_addr string   the address where this node's rescued funds should be sent to, must be a P2WPKH (native SegWit) address
       --rootkey string       BIP32 HD root key of the wallet to use for deriving the multisig keys; leave empty to prompt for lnd 24 word aezeed
 ```


### PR DESCRIPTION
`doublespendinputs` is designed to replace transactions, those new transactions should also be replacable by default. 