### PR TITLE
root+doc: change default API server to api.node-recovery.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Example (make sure you always use the latest version!):
 
 ```shell
 $ cd /tmp
-$ wget -O chantools.tar.gz https://github.com/lightninglabs/chantools/releases/download/v0.12.2/chantools-linux-amd64-v0.12.2.tar.gz
+$ wget -O chantools.tar.gz https://github.com/lightninglabs/chantools/releases/download/v0.13.4/chantools-linux-amd64-v0.13.4.tar.gz
 $ tar -zxvf chantools.tar.gz
 $ sudo mv chantools-*/chantools /usr/local/bin/
 ```
@@ -236,7 +236,7 @@ compacting the DB).
 
 6. **chantools summary**: First, `chantools` needs to find out the state of each
    channel on chain. For this, a blockchain API (by
-   default [blockstream.info](https://blockstream.info))
+   default [node-recovery.com](https://api.node-recovery.com))
    is queried. The result will be written to a file called
    `./results/summary-yyyy-mm-dd.json`. This result file will be needed for the
    next command.

--- a/cmd/chantools/root.go
+++ b/cmd/chantools/root.go
@@ -24,14 +24,14 @@ import (
 )
 
 const (
-	defaultAPIURL        = "https://blockstream.info/api"
+	defaultAPIURL        = "https://api.node-recovery.com"
 	defaultTestnetAPIURL = "https://blockstream.info/testnet/api"
 	defaultRegtestAPIURL = "http://localhost:3004"
 
 	// version is the current version of the tool. It is set during build.
 	// NOTE: When changing this, please also update the version in the
 	// download link shown in the README.
-	version = "0.13.3"
+	version = "0.13.4"
 	na      = "n/a"
 
 	// lndVersion is the current version of lnd that we support. This is

--- a/doc/chantools_closepoolaccount.md
+++ b/doc/chantools_closepoolaccount.md
@@ -29,7 +29,7 @@ chantools closepoolaccount \
 ### Options
 
 ```
-      --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string            API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --auctioneerkey string     the auctioneer's static public key (default "028e87bdd134238f8347f845d9ecc827b843d0d1e27cdcb46da704d916613f4fce")
       --bip39                    read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32           fee rate to use for the sweep transaction in sat/vByte (default 30)

--- a/doc/chantools_doublespendinputs.md
+++ b/doc/chantools_doublespendinputs.md
@@ -25,7 +25,7 @@ chantools doublespendinputs \
 ### Options
 
 ```
-      --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string            API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                    read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32           fee rate to use for the sweep transaction in sat/vByte (default 30)
   -h, --help                     help for doublespendinputs

--- a/doc/chantools_fakechanbackup.md
+++ b/doc/chantools_fakechanbackup.md
@@ -61,7 +61,7 @@ chantools fakechanbackup --from_channel_graph lncli_describegraph.json \
       --channelpoint string         funding transaction outpoint of the channel to rescue (<txid>:<txindex>) as it is displayed on 1ml.com
       --from_channel_graph string   the full LN channel graph in the JSON format that the 'lncli describegraph' returns
   -h, --help                        help for fakechanbackup
-      --multi_file string           the fake channel backup file to create (default "results/fake-2024-09-20-09-53-53.backup")
+      --multi_file string           the fake channel backup file to create (default "results/fake-2024-10-28-13-17-27.backup")
       --remote_node_addr string     the remote node connection information in the format pubkey@host:port
       --rootkey string              BIP32 HD root key of the wallet to use for encrypting the backup; leave empty to prompt for lnd 24 word aezeed
       --short_channel_id string     the short channel ID in the format <blockheight>x<transactionindex>x<outputindex>

--- a/doc/chantools_forceclose.md
+++ b/doc/chantools_forceclose.md
@@ -33,7 +33,7 @@ chantools forceclose \
 ### Options
 
 ```
-      --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string            API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                    read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --channeldb string         lnd channel.db file to use for force-closing channels
       --fromchanneldb string     channel input is in the format of an lnd channel.db file

--- a/doc/chantools_pullanchor.md
+++ b/doc/chantools_pullanchor.md
@@ -26,7 +26,7 @@ chantools pullanchor \
 
 ```
       --anchoraddr stringArray   the address of the anchor output (p2wsh or p2tr output with 330 satoshis) that should be pulled; can be specified multiple times per command to pull multiple anchors with a single transaction
-      --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string            API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                    read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --changeaddr string        the change address to send the remaining funds back to; specify 'fromseed' to derive a new address from the seed automatically
       --feerate uint32           fee rate to use for the sweep transaction in sat/vByte (default 30)

--- a/doc/chantools_recoverloopin.md
+++ b/doc/chantools_recoverloopin.md
@@ -21,7 +21,7 @@ chantools recoverloopin \
 ### Options
 
 ```
-      --apiurl string         API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string         API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                 read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32        fee rate to use for the sweep transaction in sat/vByte
   -h, --help                  help for recoverloopin

--- a/doc/chantools_rescuefunding.md
+++ b/doc/chantools_rescuefunding.md
@@ -39,7 +39,7 @@ chantools rescuefunding \
 ### Options
 
 ```
-      --apiurl string                  API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string                  API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                          read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --channeldb string               lnd channel.db file to rescue a channel from; must contain the pending channel specified with --channelpoint
       --confirmedchannelpoint string   channel outpoint that got confirmed on chain (<txid>:<txindex>); normally this is the same as the --dbchannelpoint so it will be set to that value ifthis is left empty

--- a/doc/chantools_summary.md
+++ b/doc/chantools_summary.md
@@ -22,7 +22,7 @@ chantools summary --fromchanneldb ~/.lnd/data/graph/mainnet/channel.db
 ### Options
 
 ```
-      --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string            API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --fromchanneldb string     channel input is in the format of an lnd channel.db file
       --fromsummary string       channel input is in the format of chantool's channel summary; specify '-' to read from stdin
   -h, --help                     help for summary

--- a/doc/chantools_sweepremoteclosed.md
+++ b/doc/chantools_sweepremoteclosed.md
@@ -33,7 +33,7 @@ chantools sweepremoteclosed \
 ### Options
 
 ```
-      --apiurl string           API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string           API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                   read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32          fee rate to use for the sweep transaction in sat/vByte (default 30)
   -h, --help                    help for sweepremoteclosed

--- a/doc/chantools_sweeptimelock.md
+++ b/doc/chantools_sweeptimelock.md
@@ -29,7 +29,7 @@ chantools sweeptimelock \
 ### Options
 
 ```
-      --apiurl string            API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string            API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                    read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32           fee rate to use for the sweep transaction in sat/vByte (default 30)
       --fromchanneldb string     channel input is in the format of an lnd channel.db file

--- a/doc/chantools_sweeptimelockmanual.md
+++ b/doc/chantools_sweeptimelockmanual.md
@@ -45,7 +45,7 @@ chantools sweeptimelockmanual \
 ### Options
 
 ```
-      --apiurl string               API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string               API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                       read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --channelpoint string         channel point to use for locating the channel in the channel backup file specified in the --frombackup flag, format: txid:index
       --feerate uint32              fee rate to use for the sweep transaction in sat/vByte (default 30)

--- a/doc/chantools_triggerforceclose.md
+++ b/doc/chantools_triggerforceclose.md
@@ -24,7 +24,7 @@ chantools triggerforceclose \
 ### Options
 
 ```
-      --apiurl string          API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string          API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
       --bip39                  read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --channel_point string   funding transaction outpoint of the channel to trigger the force close of (<txid>:<txindex>)
   -h, --help                   help for triggerforceclose

--- a/doc/chantools_zombierecovery_findmatches.md
+++ b/doc/chantools_zombierecovery_findmatches.md
@@ -28,7 +28,7 @@ chantools zombierecovery findmatches \
 ```
       --ambossdelay duration   the delay between each query to the Amboss GraphQL API (default 4s)
       --ambosskey string       the API key for the Amboss GraphQL API
-      --apiurl string          API URL to use (must be esplora compatible) (default "https://blockstream.info/api")
+      --apiurl string          API URL to use (must be esplora compatible) (default "https://api.node-recovery.com")
   -h, --help                   help for findmatches
       --registrations string   the raw data.txt where the registrations are stored in
 ```


### PR DESCRIPTION
The blockstream API is too unstable or blocks users after too few requests. This commit changes the default API server to api.node-recovery.com (hosted by guggero).