### PR TITLE
mod: fix swapserverrpc version with wrong tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/lightninglabs/lndclient v0.18.4-0 // indirect
-	github.com/lightninglabs/loop/swapserverrpc v1.0.11 // indirect
+	github.com/lightninglabs/loop/swapserverrpc v1.0.12 // indirect
 	github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd // indirect
 	github.com/lightninglabs/neutrino/cache v1.1.2 // indirect
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1181,8 +1181,8 @@ github.com/lightninglabs/lndclient v0.18.4-0 h1:TdorvV9UIw3fjZrNpVKn3fpsOdw2KWF2
 github.com/lightninglabs/lndclient v0.18.4-0/go.mod h1:LbINSPfKEdZuTGqqJ+ZmUxXWNvUCaDqrZeJ7/Al0Z3Y=
 github.com/lightninglabs/loop v0.29.0-beta h1:YRxZ3h41LsFOLTyvisxbijmvCf5UOUx4T0YUemdi0wA=
 github.com/lightninglabs/loop v0.29.0-beta/go.mod h1:Lc1qXyO0LoOHQVkzwxVlHTavybGGz0I1t5YozWH1WNo=
-github.com/lightninglabs/loop/swapserverrpc v1.0.11 h1:R/8c/bo4rpqm5/cfi944rj24oQUlZu+xXjzMhEDSkrc=
-github.com/lightninglabs/loop/swapserverrpc v1.0.11/go.mod h1:Ml3gMwe/iTRLvu1QGGZzXcr0DYSa9sJGwKPktLaWtwE=
+github.com/lightninglabs/loop/swapserverrpc v1.0.12 h1:A6ym5sCupNOPNsEhYEgTqWYR9C7Cev1cRpVetm6TewA=
+github.com/lightninglabs/loop/swapserverrpc v1.0.12/go.mod h1:Ml3gMwe/iTRLvu1QGGZzXcr0DYSa9sJGwKPktLaWtwE=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=


### PR DESCRIPTION
A tag was modified, leading to security errors with the `loop/swapserverrpc` dependency.