### PR TITLE
derivekey: support xpubs in addition to xprvs

### DIFF
--- a/cmd/chantools/derivekey.go
+++ b/cmd/chantools/derivekey.go
@@ -107,7 +107,7 @@ func deriveKey(extendedKey *hdkeychain.ExtendedKey, path string,
 	}
 
 	privKey, xPriv := na, na
-	if !neuter {
+	if !neuter && wif != nil {
 		privKey, xPriv = wif.String(), child.String()
 	}
 

--- a/cmd/chantools/derivekey_test.go
+++ b/cmd/chantools/derivekey_test.go
@@ -123,3 +123,23 @@ func TestDeriveKeyXpub(t *testing.T) {
 	h.assertLogContains("03dc8655d58bd4fd4326863fe34bd5cdddbefaa3b042571" +
 		"05eb1ab99aa05e01c2a")
 }
+
+func TestDeriveKeyXpubNoNeuter(t *testing.T) {
+	h := newHarness(t)
+
+	// Derive a specific key from xpub.
+	derive := &deriveKeyCommand{
+		Path: "m/5/6",
+		rootKey: &rootKey{
+			RootKey: "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap" +
+				"9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqse" +
+				"fD265TMg7usUDFdp6W1EGMcet8",
+		},
+	}
+
+	err := derive.Execute(nil, nil)
+	require.NoError(t, err)
+
+	h.assertLogContains("03dc8655d58bd4fd4326863fe34bd5cdddbefaa3b042571" +
+		"05eb1ab99aa05e01c2a")
+}

--- a/cmd/chantools/derivekey_test.go
+++ b/cmd/chantools/derivekey_test.go
@@ -82,3 +82,23 @@ func TestDeriveKeySeedBip39(t *testing.T) {
 
 	h.assertLogContains(keyContentBIP39)
 }
+
+func TestDeriveKeyXprv(t *testing.T) {
+	h := newHarness(t)
+
+	// Derive a specific key from xprv.
+	derive := &deriveKeyCommand{
+		Path: testPath,
+		rootKey: &rootKey{
+			RootKey: "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nR" +
+				"k4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejM" +
+				"RNNU3TGtRBeJgk33yuGBxrMPHi",
+		},
+	}
+
+	err := derive.Execute(nil, nil)
+	require.NoError(t, err)
+
+	h.assertLogContains("cQcdieZy2d1TAdCsa5MjmHJs2gdHcD7x22nDbhJyVTUa3Ax" +
+		"5KB3w")
+}

--- a/cmd/chantools/derivekey_test.go
+++ b/cmd/chantools/derivekey_test.go
@@ -102,3 +102,24 @@ func TestDeriveKeyXprv(t *testing.T) {
 	h.assertLogContains("cQcdieZy2d1TAdCsa5MjmHJs2gdHcD7x22nDbhJyVTUa3Ax" +
 		"5KB3w")
 }
+
+func TestDeriveKeyXpub(t *testing.T) {
+	h := newHarness(t)
+
+	// Derive a specific key from xpub.
+	derive := &deriveKeyCommand{
+		Path: "m/5/6",
+		rootKey: &rootKey{
+			RootKey: "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap" +
+				"9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqse" +
+				"fD265TMg7usUDFdp6W1EGMcet8",
+		},
+		Neuter: true,
+	}
+
+	err := derive.Execute(nil, nil)
+	require.NoError(t, err)
+
+	h.assertLogContains("03dc8655d58bd4fd4326863fe34bd5cdddbefaa3b042571" +
+		"05eb1ab99aa05e01c2a")
+}

--- a/lnd/hdkeychain.go
+++ b/lnd/hdkeychain.go
@@ -110,7 +110,8 @@ func HardenedKey(key uint32) uint32 {
 }
 
 // DeriveKey derives the public key and private key in the WIF format for a
-// given key path of the extended key.
+// given key path from the extended key. If the extendedKey is an xpub, then
+// private key is not generated and the returned WIF will be nil.
 func DeriveKey(extendedKey *hdkeychain.ExtendedKey, path string,
 	params *chaincfg.Params) (*hdkeychain.ExtendedKey, *btcec.PublicKey,
 	*btcutil.WIF, error) {
@@ -129,6 +130,11 @@ func DeriveKey(extendedKey *hdkeychain.ExtendedKey, path string,
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not derive public "+
 			"key: %w", err)
+	}
+
+	// If the extended key is xpub, we can't generate the private key.
+	if !derivedKey.IsPrivate() {
+		return derivedKey, pubKey, nil, nil
 	}
 
 	privKey, err := derivedKey.ECPrivKey()


### PR DESCRIPTION
Now it is possible to derive a public key from xpub if `--neuter` is passed:

```
chantools derivekey --rootkey xpub... --path "m/0/0" --neuter
```

Example:
```
$ chantools derivekey --testnet --rootkey tpubDDfTBtwwqxXuCej7pKYfbXeCW3inAtv1cw4knmvYTTHkw3NoKaeCNH5XdY6n6fnBPc1gWEgeurfmBVzJLfBB1hGU64LsHFzJv4ASqaHyALH --path "m/0/0" --neuter
2025-01-09 15:33:00.047 [INF] CHAN: chantools version v0.13.5 commit 

Path:                           m/0/0
Network:                        testnet3
Master Fingerprint:             dfe0654d
Public key:                     0280a3fcbeb7f770af6dd45cb0f4d02e1044eafe0d8b05bcaec79dc0478c7fa0da
Extended public key (xpub):     tpubDGveUteHeiGeoiYFcusMzsUZzEwhdT6jEG3Xuz7GXeV3QRchMoMb1dfGMkaLFn7uvQqMiUKkRwtS7d3r1CmhqGHuUpZ5ZgWuo2zNZsgLbg9
Address:                        tb1q6hk6zfzu3plh07pygqh26y48amgf0ru3fl8k6q
Legacy address:                 n126thTNJ7xUAJwiEUikXak8nUoQzxcfSk
Taproot address:                tb1ptdj7h5476hyfswvwtctqxrnwhnldgjdw5yvxe6m72ltyj6k38ajsl7g648
Private key (WIF):              n/a
Extended private key (xprv):    n/a
```

Also added tests `TestDeriveKeyXprv` and `TestDeriveKeyXpub`.