### PR TITLE
CLN: Make sweepremoteclosed and triggerforceclose CLN compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 * [Commands](#commands)
 
 This tool provides helper functions that can be used to rescue funds locked in
-`lnd` channels in case `lnd` itself cannot run properly anymore.
+`lnd` channels in case `lnd` itself cannot run properly anymore (some commands
+also support Core Lightning (CLN), check [command overview](#commands) below
+for a list of compatible commands).
 
 **WARNING**: This tool was specifically built for a certain rescue operation and
 might not be well-suited for your use case. Or not all edge cases for your needs
@@ -30,7 +32,7 @@ Example (make sure you always use the latest version!):
 
 ```shell
 $ cd /tmp
-$ wget -O chantools.tar.gz https://github.com/lightninglabs/chantools/releases/download/v0.13.4/chantools-linux-amd64-v0.13.4.tar.gz
+$ wget -O chantools.tar.gz https://github.com/lightninglabs/chantools/releases/download/v0.13.7/chantools-linux-amd64-v0.13.7.tar.gz
 $ tar -zxvf chantools.tar.gz
 $ sudo mv chantools-*/chantools /usr/local/bin/
 ```
@@ -472,44 +474,46 @@ Legend:
 - :skull: Danger of loss of funds, only use when instructed to.
 - :pushpin: Command was created for a very specific version or use case and most
   likely does not apply to 99.9% of users
+- **CLN**: Command is compatible with Core Lightning (CLN), use `--hsm_secret`
+  flag instead of root key or wallet.
 
-| Command                                                     | Use when                                                                                                                                 |
-|-------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| [chanbackup](doc/chantools_chanbackup.md)                   | :pencil: Extract a `channel.backup` file from a `channel.db` file                                                                        |
-| [closepoolaccount](doc/chantools_closepoolaccount.md)       | :pencil: Manually close an expired Lightning Pool account                                                                                |
-| [compactdb](doc/chantools_compactdb.md)                     | Run database compaction manually to reclaim space                                                                                        |
-| [createwallet](doc/chantools_createwallet.md)               | :pencil: Create a new lnd compatible wallet.db file from an existing seed or by generating a new one                                     |
-| [deletepayments](doc/chantools_deletepayments.md)           | Remove ALL payments from a `channel.db` file to reduce size                                                                              |
-| [derivekey](doc/chantools_derivekey.md)                     | :pencil: Derive a single private/public key from `lnd`'s seed, use to test seed                                                          |
-| [doublespendinputs](doc/chantools_doublespendinputs.md)     | :pencil: Tries to double spend the given inputs by deriving the private for the address and sweeping the funds to the given address      |
-| [dropchannelgraph](doc/chantools_dropchannelgraph.md)       | (:warning:) Completely drop the channel graph from a `channel.db` to force re-sync                                                       |
-| [dropgraphzombies](doc/chantools_dropgraphzombies.md)       | Drop all zombie channels from a `channel.db` to force a graph re-sync                                                                    |
-| [dumpbackup](doc/chantools_dumpbackup.md)                   | :pencil: Show the content of a `channel.backup` file as text                                                                             |
-| [dumpchannels](doc/chantools_dumpchannels.md)               | Show the content of a `channel.db` file as text                                                                                          |
-| [fakechanbackup](doc/chantools_fakechanbackup.md)           | :pencil: Create a fake `channel.backup` file from public information                                                                     |
-| [filterbackup](doc/chantools_filterbackup.md)               | :pencil: Remove a channel from a `channel.backup` file                                                                                   |
-| [fixoldbackup](doc/chantools_fixoldbackup.md)               | :pencil: (:pushpin:) Fixes an issue with old `channel.backup` files                                                                      |
-| [forceclose](doc/chantools_forceclose.md)                   | :pencil: (:skull: :warning:) Publish an old channel state from a `channel.db` file                                                       |
-| [genimportscript](doc/chantools_genimportscript.md)         | :pencil: Create a script/text file that can be used to import `lnd` keys into other software                                             |
-| [migratedb](doc/chantools_migratedb.md)                     | Upgrade the `channel.db` file to the latest version                                                                                      |
-| [pullanchor](doc/chantools_pullanchor.md)                   | :pencil: Attempt to CPFP an anchor output of a channel                                                                                   | 
-| [recoverloopin](doc/chantools_recoverloopin.md)             | :pencil: Recover funds from a failed Lightning Loop inbound swap                                                                         |
-| [removechannel](doc/chantools_removechannel.md)             | (:skull: :warning:) Remove a single channel from a `channel.db` file                                                                     |
-| [rescueclosed](doc/chantools_rescueclosed.md)               | :pencil: (:pushpin:) Rescue funds in a legacy (pre `STATIC_REMOTE_KEY`) channel output                                                   |
-| [rescuefunding](doc/chantools_rescuefunding.md)             | :pencil: (:pushpin:) Rescue funds from a funding transaction. Deprecated, use [zombierecovery](doc/chantools_zombierecovery.md) instead  |
-| [scbforceclose](doc/chantools_scbforceclose.md)             | :pencil: :warning: :skull: Force close a channel using the latest state from a channel backup. EXTREMELY DANGEROUS, read help text!      |
-| [showrootkey](doc/chantools_showrootkey.md)                 | :pencil: Display the master root key (`xprv`) from your seed (DO NOT SHARE WITH ANYONE)                                                  |
-| [signmessage](doc/chantools_signmessage.md)                 | :pencil: Sign a message with the nodes identity pubkey.                                                                                  |
-| [signpsbt](doc/chantools_signpsbt.md)                       | :pencil: Sign a Partially Signed Bitcoin Transaction (PSBT)                                                                              |
-| [signrescuefunding](doc/chantools_signrescuefunding.md)     | :pencil: (:pushpin:) Sign to funds from a funding transaction. Deprecated, use [zombierecovery](doc/chantools_zombierecovery.md) instead |
-| [summary](doc/chantools_summary.md)                         | Create a summary of channel funds from a `channel.db` file                                                                               |
-| [sweepremoteclosed](doc/chantools_sweepremoteclosed.md)     | :pencil: Find channel funds from remotely force closed channels and sweep them                                                           |
-| [sweeptimelock](doc/chantools_sweeptimelock.md)             | :pencil: Sweep funds in locally force closed channels once time lock has expired (requires `channel.db`)                                 |
-| [sweeptimelockmanual](doc/chantools_sweeptimelockmanual.md) | :pencil: Manually sweep funds in a locally force closed channel where no `channel.db` file is available                                  |
-| [triggerforceclose](doc/chantools_triggerforceclose.md)     | :pencil: (:pushpin:) Request a peer to force close a channel                                                                             |
-| [vanitygen](doc/chantools_vanitygen.md)                     | Generate an `lnd` seed for a node public key that starts with a certain sequence of hex digits                                           |
-| [walletinfo](doc/chantools_walletinfo.md)                   | Show information from a `wallet.db` file, requires access to the wallet password                                                         |
-| [zombierecovery](doc/chantools_zombierecovery.md)           | :pencil: Cooperatively rescue funds from channels where normal recovery is not possible (see [full guide here][zombie-recovery])         |
+| Command                                                     | Use when                                                                                                                                   |
+|-------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| [chanbackup](doc/chantools_chanbackup.md)                   | :pencil: Extract a `channel.backup` file from a `channel.db` file                                                                          |
+| [closepoolaccount](doc/chantools_closepoolaccount.md)       | :pencil: Manually close an expired Lightning Pool account                                                                                  |
+| [compactdb](doc/chantools_compactdb.md)                     | Run database compaction manually to reclaim space                                                                                          |
+| [createwallet](doc/chantools_createwallet.md)               | :pencil: Create a new lnd compatible wallet.db file from an existing seed or by generating a new one                                       |
+| [deletepayments](doc/chantools_deletepayments.md)           | Remove ALL payments from a `channel.db` file to reduce size                                                                                |
+| [derivekey](doc/chantools_derivekey.md)                     | :pencil: Derive a single private/public key from `lnd`'s seed, use to test seed                                                            |
+| [doublespendinputs](doc/chantools_doublespendinputs.md)     | :pencil: Tries to double spend the given inputs by deriving the private for the address and sweeping the funds to the given address        |
+| [dropchannelgraph](doc/chantools_dropchannelgraph.md)       | ( :warning: ) Completely drop the channel graph from a `channel.db` to force re-sync (not recommended while channels are open!)            |
+| [dropgraphzombies](doc/chantools_dropgraphzombies.md)       | Drop all zombie channels from a `channel.db` to force a graph re-sync                                                                      |
+| [dumpbackup](doc/chantools_dumpbackup.md)                   | :pencil: Show the content of a `channel.backup` file as text                                                                               |
+| [dumpchannels](doc/chantools_dumpchannels.md)               | Show the content of a `channel.db` file as text                                                                                            |
+| [fakechanbackup](doc/chantools_fakechanbackup.md)           | :pencil: Create a fake `channel.backup` file from public information                                                                       |
+| [filterbackup](doc/chantools_filterbackup.md)               | :pencil: Remove a channel from a `channel.backup` file                                                                                     |
+| [fixoldbackup](doc/chantools_fixoldbackup.md)               | :pencil: ( :pushpin: ) Fixes an issue with old `channel.backup` files                                                                      |
+| [forceclose](doc/chantools_forceclose.md)                   | :pencil: ( :skull: :warning: ) Publish an old channel state from a `channel.db` file                                                       |
+| [genimportscript](doc/chantools_genimportscript.md)         | :pencil: Create a script/text file that can be used to import `lnd` keys into other software                                               |
+| [migratedb](doc/chantools_migratedb.md)                     | Upgrade the `channel.db` file to the latest version                                                                                        |
+| [pullanchor](doc/chantools_pullanchor.md)                   | :pencil: Attempt to CPFP an anchor output of a channel                                                                                     | 
+| [recoverloopin](doc/chantools_recoverloopin.md)             | :pencil: Recover funds from a failed Lightning Loop inbound swap                                                                           |
+| [removechannel](doc/chantools_removechannel.md)             | (:skull: :warning:) Remove a single channel from a `channel.db` file                                                                       |
+| [rescueclosed](doc/chantools_rescueclosed.md)               | :pencil: ( :pushpin: ) Rescue funds in a legacy (pre `STATIC_REMOTE_KEY`) channel output                                                   |
+| [rescuefunding](doc/chantools_rescuefunding.md)             | :pencil: ( :pushpin: ) Rescue funds from a funding transaction. Deprecated, use [zombierecovery](doc/chantools_zombierecovery.md) instead  |
+| [scbforceclose](doc/chantools_scbforceclose.md)             | :pencil: :warning: :skull: Force close a channel using the latest state from a channel backup. EXTREMELY DANGEROUS, read help text!        |
+| [showrootkey](doc/chantools_showrootkey.md)                 | :pencil: Display the master root key (`xprv`) from your seed (DO NOT SHARE WITH ANYONE)                                                    |
+| [signmessage](doc/chantools_signmessage.md)                 | :pencil: Sign a message with the nodes identity pubkey.                                                                                    |
+| [signpsbt](doc/chantools_signpsbt.md)                       | :pencil: Sign a Partially Signed Bitcoin Transaction (PSBT)                                                                                |
+| [signrescuefunding](doc/chantools_signrescuefunding.md)     | :pencil: ( :pushpin: ) Sign to funds from a funding transaction. Deprecated, use [zombierecovery](doc/chantools_zombierecovery.md) instead |
+| [summary](doc/chantools_summary.md)                         | Create a summary of channel funds from a `channel.db` file                                                                                 |
+| [sweepremoteclosed](doc/chantools_sweepremoteclosed.md)     | :pencil: (**CLN**) Find channel funds from remotely force closed channels and sweep them                                                   |
+| [sweeptimelock](doc/chantools_sweeptimelock.md)             | :pencil: Sweep funds in locally force closed channels once time lock has expired (requires `channel.db`)                                   |
+| [sweeptimelockmanual](doc/chantools_sweeptimelockmanual.md) | :pencil: Manually sweep funds in a locally force closed channel where no `channel.db` file is available                                    |
+| [triggerforceclose](doc/chantools_triggerforceclose.md)     | :pencil: (**CLN** :pushpin: ) Request a peer to force close a channel                                                                      |
+| [vanitygen](doc/chantools_vanitygen.md)                     | Generate an `lnd` seed for a node public key that starts with a certain sequence of hex digits                                             |
+| [walletinfo](doc/chantools_walletinfo.md)                   | Show information from a `wallet.db` file, requires access to the wallet password                                                           |
+| [zombierecovery](doc/chantools_zombierecovery.md)           | :pencil: (**CLN**) Cooperatively rescue funds from channels where normal recovery is not possible (see [full guide here][zombie-recovery]) |
 
 [safety]: https://github.com/lightningnetwork/lnd/blob/master/docs/safety.md
 

--- a/cmd/chantools/sweepremoteclosed.go
+++ b/cmd/chantools/sweepremoteclosed.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -16,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/chantools/btc"
+	"github.com/lightninglabs/chantools/cln"
 	"github.com/lightninglabs/chantools/lnd"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -37,6 +39,9 @@ type sweepRemoteClosedCommand struct {
 	Publish        bool
 	SweepAddr      string
 	FeeRate        uint32
+
+	HsmSecret   string
+	PeerPubKeys string
 
 	rootKey *rootKey
 	cmd     *cobra.Command
@@ -92,19 +97,27 @@ Supported remote force-closed channel types are:
 			"use for the sweep transaction in sat/vByte",
 	)
 
+	cc.cmd.Flags().StringVar(
+		&cc.HsmSecret, "hsm_secret", "", "the hex encoded HSM secret "+
+			"to use for deriving the multisig keys for a CLN "+
+			"node; obtain by running 'xxd -p -c32 "+
+			"~/.lightning/bitcoin/hsm_secret'",
+	)
+	cc.cmd.Flags().StringVar(
+		&cc.PeerPubKeys, "peers", "", "comma separated list of "+
+			"hex encoded public keys of the remote peers "+
+			"to recover funds from, only required when using "+
+			"--hsm_secret to derive the keys",
+	)
+
 	cc.rootKey = newRootKey(cc.cmd, "sweeping the wallet")
 
 	return cc.cmd
 }
 
 func (c *sweepRemoteClosedCommand) Execute(_ *cobra.Command, _ []string) error {
-	extendedKey, err := c.rootKey.read()
-	if err != nil {
-		return fmt.Errorf("error reading root key: %w", err)
-	}
-
 	// Make sure sweep addr is set.
-	err = lnd.CheckAddress(
+	err := lnd.CheckAddress(
 		c.SweepAddr, chainParams, true, "sweep", lnd.AddrTypeP2WKH,
 		lnd.AddrTypeP2TR,
 	)
@@ -120,9 +133,93 @@ func (c *sweepRemoteClosedCommand) Execute(_ *cobra.Command, _ []string) error {
 		c.FeeRate = defaultFeeSatPerVByte
 	}
 
+	var (
+		signer      lnd.ChannelSigner
+		estimator   input.TxWeightEstimator
+		sweepScript []byte
+		targets     []*targetAddr
+	)
+	switch {
+	case c.HsmSecret != "":
+		secretBytes, err := hex.DecodeString(c.HsmSecret)
+		if err != nil {
+			return fmt.Errorf("error decoding HSM secret: %w", err)
+		}
+
+		var hsmSecret [32]byte
+		copy(hsmSecret[:], secretBytes)
+
+		if c.PeerPubKeys == "" {
+			return errors.New("invalid peer public keys, must be " +
+				"a comma separated list of hex encoded " +
+				"public keys")
+		}
+
+		var pubKeys []*btcec.PublicKey
+		for _, pubKeyHex := range strings.Split(c.PeerPubKeys, ",") {
+			pkHex, err := hex.DecodeString(pubKeyHex)
+			if err != nil {
+				return fmt.Errorf("error decoding peer "+
+					"public key hex %s: %w", pubKeyHex, err)
+			}
+
+			pk, err := btcec.ParsePubKey(pkHex)
+			if err != nil {
+				return fmt.Errorf("error parsing peer public "+
+					"key hex %s: %w", pubKeyHex, err)
+			}
+
+			pubKeys = append(pubKeys, pk)
+		}
+
+		signer = &cln.Signer{
+			HsmSecret: hsmSecret,
+		}
+
+		targets, err = findTargetsCln(
+			hsmSecret, pubKeys, c.APIURL, c.RecoveryWindow,
+		)
+		if err != nil {
+			return fmt.Errorf("error finding targets: %w", err)
+		}
+
+		sweepScript, err = lnd.CheckAndEstimateAddress(
+			c.SweepAddr, chainParams, &estimator, "sweep",
+		)
+		if err != nil {
+			return err
+		}
+
+	default:
+		extendedKey, err := c.rootKey.read()
+		if err != nil {
+			return fmt.Errorf("error reading root key: %w", err)
+		}
+
+		signer = &lnd.Signer{
+			ExtendedKey: extendedKey,
+			ChainParams: chainParams,
+		}
+
+		targets, err = findTargetsLnd(
+			extendedKey, c.APIURL, c.RecoveryWindow,
+		)
+		if err != nil {
+			return fmt.Errorf("error finding targets: %w", err)
+		}
+
+		sweepScript, err = lnd.PrepareWalletAddress(
+			c.SweepAddr, chainParams, &estimator, extendedKey,
+			"sweep",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	return sweepRemoteClosed(
-		extendedKey, c.APIURL, c.SweepAddr, c.RecoveryWindow, c.FeeRate,
-		c.Publish,
+		signer, &estimator, sweepScript, targets,
+		newExplorerAPI(c.APIURL), c.FeeRate, c.Publish,
 	)
 }
 
@@ -135,17 +232,8 @@ type targetAddr struct {
 	scriptTree *input.CommitScriptTree
 }
 
-func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
-	sweepAddr string, recoveryWindow uint32, feeRate uint32,
-	publish bool) error {
-
-	var estimator input.TxWeightEstimator
-	sweepScript, err := lnd.PrepareWalletAddress(
-		sweepAddr, chainParams, &estimator, extendedKey, "sweep",
-	)
-	if err != nil {
-		return err
-	}
+func findTargetsLnd(extendedKey *hdkeychain.ExtendedKey, apiURL string,
+	recoveryWindow uint32) ([]*targetAddr, error) {
 
 	var (
 		targets []*targetAddr
@@ -157,17 +245,18 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 			index)
 		parsedPath, err := lnd.ParsePath(path)
 		if err != nil {
-			return fmt.Errorf("error parsing path: %w", err)
+			return nil, fmt.Errorf("error parsing path: %w", err)
 		}
 
 		hdKey, err := lnd.DeriveChildren(extendedKey, parsedPath)
 		if err != nil {
-			return fmt.Errorf("eror deriving children: %w", err)
+			return nil, fmt.Errorf("eror deriving children: %w",
+				err)
 		}
 
 		privKey, err := hdKey.ECPrivKey()
 		if err != nil {
-			return fmt.Errorf("could not derive private "+
+			return nil, fmt.Errorf("could not derive private "+
 				"key: %w", err)
 		}
 
@@ -181,7 +270,7 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 			}, api,
 		)
 		if err != nil {
-			return fmt.Errorf("could not query API for "+
+			return nil, fmt.Errorf("could not query API for "+
 				"addresses with funds: %w", err)
 		}
 		targets = append(targets, foundTargets...)
@@ -193,13 +282,59 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 		api, recoveryWindow, extendedKey,
 	)
 	if err != nil && !errors.Is(err, errAddrNotFound) {
-		return fmt.Errorf("could not check ancient channel points: %w",
-			err)
+		return nil, fmt.Errorf("could not check ancient channel "+
+			"points: %w", err)
 	}
 
 	if len(ancientChannelTargets) > 0 {
 		targets = append(targets, ancientChannelTargets...)
 	}
+
+	return targets, nil
+}
+
+func findTargetsCln(hsmSecret [32]byte, pubKeys []*btcec.PublicKey,
+	apiURL string, recoveryWindow uint32) ([]*targetAddr, error) {
+
+	var (
+		targets []*targetAddr
+		api     = newExplorerAPI(apiURL)
+	)
+	for _, pubKey := range pubKeys {
+		for index := range recoveryWindow {
+			desc := &keychain.KeyDescriptor{
+				PubKey: pubKey,
+				KeyLocator: keychain.KeyLocator{
+					Family: keychain.KeyFamilyPaymentBase,
+					Index:  index,
+				},
+			}
+			_, privKey, err := cln.DeriveKeyPair(hsmSecret, desc)
+			if err != nil {
+				return nil, fmt.Errorf("could not derive "+
+					"private key: %w", err)
+			}
+
+			foundTargets, err := queryAddressBalances(
+				privKey.PubKey(), desc, api,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("could not query API "+
+					"for addresses with funds: %w", err)
+			}
+			targets = append(targets, foundTargets...)
+		}
+	}
+
+	log.Infof("Found %d addresses with funds to sweep.", len(targets))
+
+	return targets, nil
+}
+
+func sweepRemoteClosed(signer lnd.ChannelSigner,
+	estimator *input.TxWeightEstimator, sweepScript []byte,
+	targets []*targetAddr, api *btc.ExplorerAPI, feeRate uint32,
+	publish bool) error {
 
 	// Create estimator and transaction template.
 	var (
@@ -332,13 +467,7 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 	}}
 
 	// Sign the transaction now.
-	var (
-		signer = &lnd.Signer{
-			ExtendedKey: extendedKey,
-			ChainParams: chainParams,
-		}
-		sigHashes = txscript.NewTxSigHashes(sweepTx, prevOutFetcher)
-	)
+	var sigHashes = txscript.NewTxSigHashes(sweepTx, prevOutFetcher)
 	for idx, desc := range signDescs {
 		desc.SigHashes = sigHashes
 		desc.InputIndex = idx
@@ -370,6 +499,13 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 			// P2WKH descriptor to be set to the pkScript of the
 			// output...
 			desc.WitnessScript = desc.Output.PkScript
+
+			// For CLN we need to activate a flag to make sure we
+			// put the correct public key on the witness stack.
+			if clnSigner, ok := signer.(*cln.Signer); ok {
+				clnSigner.SwapDescKeyAfterDerive = true
+			}
+
 			witness, err := input.CommitSpendNoDelay(
 				signer, desc, sweepTx,
 				len(desc.SingleTweak) == 0,
@@ -382,7 +518,7 @@ func sweepRemoteClosed(extendedKey *hdkeychain.ExtendedKey, apiURL,
 	}
 
 	var buf bytes.Buffer
-	err = sweepTx.Serialize(&buf)
+	err := sweepTx.Serialize(&buf)
 	if err != nil {
 		return err
 	}

--- a/cmd/chantools/zombierecovery_findmatches.go
+++ b/cmd/chantools/zombierecovery_findmatches.go
@@ -62,6 +62,10 @@ P.S.: If you don't want to be notified about future matches, please let me know.
 `
 )
 
+type gqAddress struct {
+	Address string `graphql:"addr"`
+}
+
 type gqChannel struct {
 	ChanPoint   string `graphql:"chan_point"`
 	Capacity    string `graphql:"capacity"`
@@ -70,6 +74,11 @@ type gqChannel struct {
 	} `graphql:"closure_info"`
 	Node1     string `graphql:"node1_pub"`
 	Node2     string `graphql:"node2_pub"`
+	Node2Info struct {
+		Node struct {
+			Addresses []*gqAddress `graphql:"addresses"`
+		} `graphql:"node"`
+	} `graphql:"node2_info"`
 	ChannelID string `graphql:"long_channel_id"`
 }
 

--- a/doc/chantools_sweepremoteclosed.md
+++ b/doc/chantools_sweepremoteclosed.md
@@ -37,6 +37,8 @@ chantools sweepremoteclosed \
       --bip39                   read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --feerate uint32          fee rate to use for the sweep transaction in sat/vByte (default 30)
   -h, --help                    help for sweepremoteclosed
+      --hsm_secret string       the hex encoded HSM secret to use for deriving the multisig keys for a CLN node; obtain by running 'xxd -p -c32 ~/.lightning/bitcoin/hsm_secret'
+      --peers string            comma separated list of hex encoded public keys of the remote peers to recover funds from, only required when using --hsm_secret to derive the keys
       --publish                 publish sweep TX to the chain API instead of just printing the TX
       --recoverywindow uint32   number of keys to scan per derivation path (default 200)
       --rootkey string          BIP32 HD root key of the wallet to use for sweeping the wallet; leave empty to prompt for lnd 24 word aezeed

--- a/doc/chantools_triggerforceclose.md
+++ b/doc/chantools_triggerforceclose.md
@@ -28,6 +28,7 @@ chantools triggerforceclose \
       --bip39                  read a classic BIP39 seed and passphrase from the terminal instead of asking for lnd seed format or providing the --rootkey flag
       --channel_point string   funding transaction outpoint of the channel to trigger the force close of (<txid>:<txindex>)
   -h, --help                   help for triggerforceclose
+      --hsm_secret string      the hex encoded HSM secret to use for deriving the node key for a CLN node; obtain by running 'xxd -p -c32 ~/.lightning/bitcoin/hsm_secret'
       --peer string            remote peer address (<pubkey>@<host>[:<port>])
       --rootkey string         BIP32 HD root key of the wallet to use for deriving the identity key; leave empty to prompt for lnd 24 word aezeed
       --torproxy string        SOCKS5 proxy to use for Tor connections (to .onion addresses)

--- a/lnd/hdkeychain.go
+++ b/lnd/hdkeychain.go
@@ -477,8 +477,18 @@ func PrepareWalletAddress(addr string, chainParams *chaincfg.Params,
 			return nil, err
 		}
 
+		if estimator != nil {
+			estimator.AddP2WKHOutput()
+		}
+
 		return txscript.PayToAddrScript(p2wkhAddr)
 	}
+
+	return CheckAndEstimateAddress(addr, chainParams, estimator, hint)
+}
+
+func CheckAndEstimateAddress(addr string, chainParams *chaincfg.Params,
+	estimator *input.TxWeightEstimator, hint string) ([]byte, error) {
 
 	parsedAddr, err := ParseAddress(addr, chainParams)
 	if err != nil {

--- a/lnd/signer.go
+++ b/lnd/signer.go
@@ -21,8 +21,13 @@ import (
 )
 
 type ChannelSigner interface {
+	input.MuSig2Signer
+
 	SignOutputRaw(tx *wire.MsgTx,
 		signDesc *input.SignDescriptor) (input.Signature, error)
+
+	ComputeInputScript(tx *wire.MsgTx,
+		desc *input.SignDescriptor) (*input.Script, error)
 
 	FetchPrivateKey(descriptor *keychain.KeyDescriptor) (
 		*btcec.PrivateKey, error)
@@ -133,6 +138,7 @@ func SignOutputRawWithPrivateKey(tx *wire.MsgTx,
 	// Chop off the sighash flag at the end of the signature.
 	return ecdsa.ParseDERSignature(sig[:len(sig)-1])
 }
+
 func (s *Signer) ComputeInputScript(_ *wire.MsgTx, _ *input.SignDescriptor) (
 	*input.Script, error) {
 


### PR DESCRIPTION
Makes the `sweepremoteclosed` and `triggerforceclose` commands compatible with CLN.

Make sure to supply all peer public keys as a comma separated list to the `sweepremoteclosed` command with the `--peers` command line flag!
